### PR TITLE
Allow manual workflow runs

### DIFF
--- a/.github/workflows/build_and_test_library.yml
+++ b/.github/workflows/build_and_test_library.yml
@@ -1,6 +1,7 @@
 name: Build and Test Client Library
 # Update the paths once you have created a client library build
 on:
+  workflow_dispatch:
   push:
     tags:
       - "*"


### PR DESCRIPTION
Needed to manually run the build workflow and refresh artifacts available for CI in grantami-recordlists 