### PR TITLE
CI - Fix Release Dependency

### DIFF
--- a/.github/workflows/build_and_test_library.yml
+++ b/.github/workflows/build_and_test_library.yml
@@ -82,7 +82,7 @@ jobs:
   release:
     name: "Release"
     if: contains(github.ref, 'refs/tags') && github.event_name == 'push'
-    needs: build
+    needs: build-library
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
Change the release job to depend on `build-library` not `build`