### PR TITLE
Use token for checkout

### DIFF
--- a/.github/workflows/generate_library.yml
+++ b/.github/workflows/generate_library.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.ref }}
+        token: ${{ secrets.REPO_TOKEN }}
     
     - name: "Set up JDK 11"
       uses: actions/setup-java@v3


### PR DESCRIPTION
Use a token to checkout the repo if we are potentially going to create a commit.

Dependabot-authored CI is currently failing because it doesn't have write permissions to the repo. I believe this is because the default token that is used for dependabot PRs doesn't have those permissions.

According to the `EndBug/add-and-commit` action, this token should be added when the repo is first cloned. Not 100% certain this is the right token, but we'll find out if we merge this and rebase the dependabot PR.