### PR TITLE
Maint: fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
       - "maintenance"
       
   - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/ansys-product-library-openapi/" # Location of package manifests
+    directory: "/ansys-grantami-serverapi-openapi/" # Location of package manifests
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
Dependabot isn't running correctly and doesn't update the Python project dependencies. This PR fixes the path in the dependabot config, which should let the bot see the pyproject.tml file