### PR TITLE
Fix classifier

### DIFF
--- a/ansys-grantami-serverapi-openapi/pyproject.toml
+++ b/ansys-grantami-serverapi-openapi/pyproject.toml
@@ -14,7 +14,7 @@ documentation = "https://grantami.docs.pyansys.com"
 readme = "README.md"
 keywords = ["Ansys", "OpenAPI"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Change the classifier to Alpha.

There are still additional changes expected in the Server API swagger.json, but I think the OpenAPI client template and the recordlist, jobs, and search APIs are essentially where we need them for testing, so I've gone with the alpha designation.