### PR TITLE
Switch to on-demand publishing to private PyPI

### DIFF
--- a/.github/workflows/build_and_test_library.yml
+++ b/.github/workflows/build_and_test_library.yml
@@ -2,6 +2,14 @@ name: 'CI'
 # Update the paths once you have created a client library build
 on:
   workflow_dispatch:
+    inputs:
+      publish-to-private-pypi:
+        description: Whether to publish the build to the private PyPI
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+        default: 'false'
   push:
     tags:
       - "*"
@@ -89,7 +97,7 @@ jobs:
     name: "Publish"
     runs-on: ubuntu-latest
     needs: [build-library]
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
+    if: (github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main') && (inputs.publish-to-private-pypi == 'true')
     steps:
       - name: "Release to private PyPI"
         uses: ansys/actions/release-pypi-private@v7


### PR DESCRIPTION
Some PR merges (e.g. dependabot PRs) don't result in code generation, and therefore don't auto-increment the dev version number. To avoid trying to publish multiple builds with the same version number, switch to an on-demand approach.