### PR TITLE
Use PyPI Trusted Publisher approach for releases

### DIFF
--- a/.github/workflows/build_and_test_library.yml
+++ b/.github/workflows/build_and_test_library.yml
@@ -111,13 +111,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-library]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: "Release to public PyPI"
         uses: ansys/actions/release-pypi-public@v7
         with:
           library-name: ${{ env.LIBRARY_NAME }}
-          twine-username: "__token__"
-          twine-token: ${{ secrets.PYPI_TOKEN }}
+          use-trusted-publisher: true
 
       - name: "Release to private PyPI"
         uses: ansys/actions/release-pypi-private@v7


### PR DESCRIPTION
Closes #206 

Use trusted publisher approach for release to PyPI.
Configured the `release` environment on the repository.
Repository has been added to the list of authorized repositories.