### PR TITLE
Include changes from PR #200 in release workflow

### DIFF
--- a/.github/workflows/build_and_test_library.yml
+++ b/.github/workflows/build_and_test_library.yml
@@ -7,15 +7,17 @@ on:
       - "*"
     paths:
       - "ansys-grantami-serverapi-openapi/**"
+      - ".github/workflows/build_and_test_library.yml"
   pull_request:
     paths:
       - "ansys-grantami-serverapi-openapi/**"
+      - ".github/workflows/build_and_test_library.yml"
 
 env:
   MAIN_PYTHON_VERSION: '3.10'
+  LIBRARY_NAME: 'ansys-grantami-serverapi-openapi'
 
 jobs:
-
 
   tests:
     name: "Test Python ${{ matrix.python-version }}"
@@ -39,14 +41,14 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install poetry
           poetry install
-        working-directory: ansys-grantami-serverapi-openapi
+        working-directory: ${{ env.LIBRARY_NAME }}
 
       - name: "Test with pytest"
-        working-directory: ansys-grantami-serverapi-openapi
+        working-directory: ${{ env.LIBRARY_NAME }}
         run: poetry run pytest
 
       - name: "Run mypy"
-        working-directory: ansys-grantami-serverapi-openapi
+        working-directory: ${{ env.LIBRARY_NAME }}
         run: poetry run mypy
 
   build-library:
@@ -68,22 +70,21 @@ jobs:
           python -m pip install build twine
 
       - name: "Create source and wheel artifacts"
-        working-directory: ansys-grantami-serverapi-openapi
+        working-directory: ${{ env.LIBRARY_NAME }}
         run: |
           python -m build .
 
       - name: "Validate integrity of artifacts"
-        working-directory: ansys-grantami-serverapi-openapi
+        working-directory: ${{ env.LIBRARY_NAME }}
         run: |
           python -m twine check dist/*
 
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v4
         with:
-          name: ansys-grantami-serverapi-openapi-wheel
-          path: ansys-grantami-serverapi-openapi/dist/
+          name: ${{ env.LIBRARY_NAME }}-artifacts
+          path: ${{ env.LIBRARY_NAME }}/dist/
           retention-days: 7
-
 
   release:
     name: "Release"
@@ -101,42 +102,21 @@ jobs:
           library-name: ${{ env.LIBRARY_NAME }}
           use-trusted-publisher: true
 
-      - name: "Checkout the project"
-        uses: actions/checkout@v4
-
-      - name: "Set up Python ${{ env.MAIN_PYTHON_VERSION }}"
-        uses: actions/setup-python@v5
+      - name: "Release to private PyPI"
+        uses: ansys/actions/release-pypi-private@v7
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          library-name: ${{ env.LIBRARY_NAME }}
+          twine-username: "__token__"
+          twine-token: ${{ secrets.PYPI_TOKEN }}
 
       - name: "Download distribution artifacts"
         uses: actions/download-artifact@v4
         with:
-          name: ansys-grantami-serverapi-openapi-wheel
-          path: ~/dist
-
-      - name: "Install Python dependencies"
-        run: |
-          python -m pip install --upgrade pip twine
-
-      - name: "Release to private PyPI"
-        run: |
-          python -m twine upload --verbose --skip-existing --non-interactive ~/dist/*.whl
-        env:
-          TWINE_USERNAME: "__token__"
-          TWINE_PASSWORD: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
-          TWINE_REPOSITORY_URL: "https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/upload"
-
-      - name: "Release to public PyPI"
-        run: |
-          python -m twine upload --verbose --skip-existing --non-interactive ~/dist/*.whl
-        env:
-          TWINE_USERNAME: "__token__"
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-          TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
+          name: ${{ env.LIBRARY_NAME }}-artifacts
+          path: ${{ env.LIBRARY_NAME }}-artifacts
 
       - name: "Release to GitHub"
         uses: softprops/action-gh-release@v2
         with:
-          files: ~/dist/ansys-grantami-serverapi-openapi-wheel/*.whl
+          files: ${{ env.LIBRARY_NAME }}-artifacts/*.whl
           generate_release_notes: true


### PR DESCRIPTION
Before attempting the previous release (https://github.com/ansys/grantami-serverapi-openapi/actions/runs/14667706025) I cherry-picked the changes from #235. However, these changes were based on a previous PR, #200, which also needed to be included. As a result, the release failed.

This PR copies a subset of changes from #200. We don't want all the changes related to labels, but we do need to update the build and release workflow to use the library-name environment variable.