### PR TITLE
Fix private PyPI token

### DIFF
--- a/.github/workflows/build_and_test_library.yml
+++ b/.github/workflows/build_and_test_library.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           library-name: ${{ env.LIBRARY_NAME }}
           twine-username: "__token__"
-          twine-token: ${{ secrets.PYPI_TOKEN }}
+          twine-token: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
 
       - name: "Download distribution artifacts"
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This PR fixes token used to publish to private PyPI. This was the cause of the failure of the private publish step in the v3.0.1 release.