### PR TITLE
Use PyPI-authored publish action

### DIFF
--- a/.github/workflows/build_and_test_library.yml
+++ b/.github/workflows/build_and_test_library.yml
@@ -116,11 +116,19 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - name: "Release to public PyPI"
-        uses: ansys/actions/release-pypi-public@v9
+      - name: "Download the library artifacts from build-library step"
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806  # v4.1.9
         with:
-          library-name: ${{ env.LIBRARY_NAME }}
-          use-trusted-publisher: true
+          name: ${{ env.LIBRARY_NAME }}-artifacts
+          path: ${{ env.LIBRARY_NAME }}-artifacts
+
+      - name: "Upload artifacts to PyPI using trusted publisher"
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
+        with:
+          repository-url: "https://upload.pypi.org/legacy/"
+          print-hash: true
+          packages-dir: ${{ env.LIBRARY_NAME }}-artifacts
+          skip-existing: false
 
       - name: "Release to private PyPI"
         uses: ansys/actions/release-pypi-private@v9


### PR DESCRIPTION
Use PyPI-authored publish action, instead of the Ansys-wrapped version. This ensures support for metadata 2.4.

Copied from https://actions.docs.ansys.com/version/stable/migrations/release-pypi-trusted-publisher.html#release-pypi-trusted-publisher