### PR TITLE
Generate build provenance attestation

### DIFF
--- a/.github/workflows/build_and_test_library.yml
+++ b/.github/workflows/build_and_test_library.yml
@@ -86,6 +86,11 @@ jobs:
         run: |
           python -m twine check dist/*
 
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        with:
+          subject-path: ${{ env.LIBRARY_NAME }}/dist/
+
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_and_test_library.yml
+++ b/.github/workflows/build_and_test_library.yml
@@ -62,6 +62,9 @@ jobs:
     name: "Build library"
     runs-on: ubuntu-latest
     needs: tests
+    permissions:
+      id-token: write
+      attestations: write
     steps:
 
       - name: "Checkout the project"


### PR DESCRIPTION
Closes #365 

This is using the github official action, and exactly what the ansys action does in the background.