### PR TITLE
chore: add __version__ at package level

### DIFF
--- a/ansys-grantami-serverapi-openapi/src/ansys/grantami/serverapi_openapi/__init__.py
+++ b/ansys-grantami-serverapi-openapi/src/ansys/grantami/serverapi_openapi/__init__.py
@@ -19,3 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
+import importlib.metadata as importlib_metadata
+
+__version__ = importlib_metadata.version("ansys-grantami-serverapi-openapi")


### PR DESCRIPTION
Using `__version__` is a common way to retrieve the version of a package among PyAnsys packages.
This PR simply adds the variable at package level.