### PR TITLE
Allow pyansys-ci-bot to trigger CI on PR create

### DIFF
--- a/.github/workflows/generate_library.yml
+++ b/.github/workflows/generate_library.yml
@@ -13,7 +13,7 @@ jobs:
   generate-client-library:
     name: "Generate and update client library"
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'pyansys-ci-bot' }}
+    if: ${{ github.actor != 'pyansys-ci-bot' || github.event.action == 'opened' }}
     env:
       IS_RELEASE_BRANCH: ${{ (github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release/')) || (github.event_name == 'workflow_dispatch' && startsWith(github.ref_name, 'release/')) }}
     steps:

--- a/.github/workflows/generate_library.yml
+++ b/.github/workflows/generate_library.yml
@@ -13,7 +13,7 @@ jobs:
   generate-client-library:
     name: "Generate and update client library"
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'pyansys-ci-bot' || github.event.action == 'opened' }}
+    if: ${{ !(github.actor == 'pyansys-ci-bot' && github.event.action == 'synchronize') }}
     env:
       IS_RELEASE_BRANCH: ${{ (github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release/')) || (github.event_name == 'workflow_dispatch' && startsWith(github.ref_name, 'release/')) }}
     steps:


### PR DESCRIPTION
We have a condition for the workflow, which previously wouldn't trigger the 'Generate client library' action if the event was triggered by the bot that pushed the previous 'generate' commit.

As part of #476 I changed the 'generate' commit to be pushed by the same actor that creates the PR. As a result, a simple 'actor' check is no longer sufficient, because the same actor creates the PR (SHOULD trigger this workflow) and pushes the commit (SHOULDN'T trigger this workflow).

I've made this check slightly more granular. It should now allow the bot to trigger the workflow for anything other than a synchronize event. Right now the pyansys-ci-bot actor is only responsible for create and synchronize events, but in future we may have the bot do additional things, so this seemed like the most robust way of implementing it.

Not 100% sure of the syntax, but we'll just have to try it and see.